### PR TITLE
Joint control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(MSG_FILES
   Finished.msg
   WholeBodyCommand.msg
   WholeBodyState.msg
+  SemanticBool.msg
   SemanticFloat64.msg
   SemanticFloat64Array.msg
   SemanticVector3.msg

--- a/msg/ArmCommand.msg
+++ b/msg/ArmCommand.msg
@@ -11,11 +11,10 @@ uint8 type
 
 # Cartesian goal for the arm.
 # Note: The header will be used to resolve goal using tf.
-geometry_msgs/PoseStamped goal
+geometry_msgs/PoseStamped goal_pose
 
 # Joint goal for the arm.
 float64[] goal_configuration
 
-# A flag to activate processing of this command.
-# If this FALSE, the rest of this command will be ignored.
-bool process # TO BE DEPRECATED, SOON
+# List of internal double expressions with thresholds to decide convergence
+giskard_msgs/SemanticFloat64[] convergence_thresholds

--- a/msg/ArmCommand.msg
+++ b/msg/ArmCommand.msg
@@ -1,10 +1,21 @@
 # A command message for robotic manipulators that exposes a couple
 # of alternative ways of specifying commands.
 
+# Definitions of possible values used for type
+uint8 IGNORE_GOAL=0 # Ignore the rest of this command.
+uint8 CARTESIAN_GOAL=1 # Use the PoseStamped.
+uint8 JOINT_GOAL=2 # Use the list of floats.
+
+# use one of the above constants to indicate the type of command
+uint8 type
+
 # Cartesian goal for the arm.
-# Hote: The header will be used to resolve goal using tf.
+# Note: The header will be used to resolve goal using tf.
 geometry_msgs/PoseStamped goal
+
+# Joint goal for the arm.
+float64[] goal_configuration
 
 # A flag to activate processing of this command.
 # If this FALSE, the rest of this command will be ignored.
-bool process
+bool process # TO BE DEPRECATED, SOON

--- a/msg/ControllerFeedback.msg
+++ b/msg/ControllerFeedback.msg
@@ -2,13 +2,17 @@
 
 # Header to communicate timestamps, and being compatible with message-filters.
 std_msgs/Header header
+# Flag to indicate whether the watchdog is active
+bool watchdog_active
 # Commands issued to motor controllers, expressed with semantics hints.
 giskard_msgs/SemanticFloat64[] commands
 # Slack values of task functions, expressed with semantics hints.
 giskard_msgs/SemanticFloat64[] slacks
-# Internal double expressions wired through for debugging or monitoring
+# Internal double expressions used to decide convergence
+giskard_msgs/SemanticFloat64[] convergence_features
+# Internal double expressions wired through for debugging
 giskard_msgs/SemanticFloat64[] doubles
-# Internal vector expressions wired through for debugging or monitoring
+# Internal vector expressions wired through for debugging
 giskard_msgs/SemanticVector3[] vectors
 
 # Command that the controller is currently pursuing

--- a/msg/ControllerFeedback.msg
+++ b/msg/ControllerFeedback.msg
@@ -10,3 +10,8 @@ giskard_msgs/SemanticFloat64[] slacks
 giskard_msgs/SemanticFloat64[] doubles
 # Internal vector expressions wired through for debugging or monitoring
 giskard_msgs/SemanticVector3[] vectors
+
+# Command that the controller is currently pursuing
+giskard_msgs/WholeBodyCommand current_command
+# Hash of the current command calculated by the controller
+uint64 current_command_hash

--- a/msg/SemanticBool.msg
+++ b/msg/SemanticBool.msg
@@ -1,0 +1,7 @@
+# A bool with semantics hint attached.
+# Note: I know this is not much but better than just the bool. ;)
+
+# Hint about the semantics of this number. Examples: frame_id, joint-name, or task dimension.
+string semantics
+# The actual value communicated.
+bool value

--- a/msg/WholeBodyCommand.msg
+++ b/msg/WholeBodyCommand.msg
@@ -4,3 +4,4 @@
 
 giskard_msgs/ArmCommand right_ee
 giskard_msgs/ArmCommand left_ee
+giskard_msgs/SemanticFloat64[] convergence_thresholds

--- a/msg/WholeBodyCommand.msg
+++ b/msg/WholeBodyCommand.msg
@@ -4,4 +4,3 @@
 
 giskard_msgs/ArmCommand right_ee
 giskard_msgs/ArmCommand left_ee
-giskard_msgs/SemanticFloat64[] convergence_thresholds

--- a/msg/WholeBodyState.msg
+++ b/msg/WholeBodyState.msg
@@ -6,6 +6,9 @@ duration running_time
 float64 left_arm_max_vel
 float64 right_arm_max_vel
 float64 torso_vel
+giskard_msgs/SemanticFloat64[] feature_values # internal values used to decide convergence
+
+# ALL OF THE BELOW ARE DEPRECATED
 float64 left_arm_pos_error
 float64 left_arm_rot_error
 float64 right_arm_pos_error
@@ -17,6 +20,9 @@ bool motion_old # true, if time passed since start of motion is above threshold
 bool torso_moving # true, if torso velocity is above threshold
 bool left_arm_moving # true, if velocity of any joint of left arm is above threshold
 bool right_arm_moving # true, if velocity of any joint of right arm is above threshold
+giskard_msgs/SemanticBool[] feature_flags # true, if the corresponding feature values are below a threshold
+
+# ALL OF THE BELOW ARE DEPRECATED
 bool left_arm_pos_converged # true, if position error of left arm is below threshold
 bool left_arm_rot_converged # true, if orientation error of left arm is below threshold
 bool right_arm_pos_converged # true, if position error of right arm is below threshold

--- a/msg/WholeBodyState.msg
+++ b/msg/WholeBodyState.msg
@@ -6,13 +6,7 @@ duration running_time
 float64 left_arm_max_vel
 float64 right_arm_max_vel
 float64 torso_vel
-giskard_msgs/SemanticFloat64[] feature_values # internal values used to decide convergence
-
-# ALL OF THE BELOW ARE DEPRECATED
-float64 left_arm_pos_error
-float64 left_arm_rot_error
-float64 right_arm_pos_error
-float64 right_arm_rot_error
+giskard_msgs/SemanticFloat64[] convergence_values # internal values used to decide convergence
 
 # classification results used to decide whether action succeeded
 bool motion_started # true, as soon low-level controller has started execution the command
@@ -20,10 +14,4 @@ bool motion_old # true, if time passed since start of motion is above threshold
 bool torso_moving # true, if torso velocity is above threshold
 bool left_arm_moving # true, if velocity of any joint of left arm is above threshold
 bool right_arm_moving # true, if velocity of any joint of right arm is above threshold
-giskard_msgs/SemanticBool[] feature_flags # true, if the corresponding feature values are below a threshold
-
-# ALL OF THE BELOW ARE DEPRECATED
-bool left_arm_pos_converged # true, if position error of left arm is below threshold
-bool left_arm_rot_converged # true, if orientation error of left arm is below threshold
-bool right_arm_pos_converged # true, if position error of right arm is below threshold
-bool right_arm_rot_converged # true, if orientation error of right arm is below threshold
+giskard_msgs/SemanticBool[] convergence_flags # true, if the corresponding feature values are below a threshold


### PR DESCRIPTION
- deprecated in ArmCommand: `process`
- deprecated in WholeBodyState: various Cartesian-specific feedback
- added in ArmCommand: flexibel specification of goal thresholds, specification of joint goals
- added in WholeBodyState: flexibel feedback about convergence
